### PR TITLE
Allow Orders

### DIFF
--- a/.artifactsmmo-engine.yaml.example
+++ b/.artifactsmmo-engine.yaml.example
@@ -4,21 +4,16 @@ characters:
   - name: Milnor
     actions:
       - gather
-      - bank
   - name: Bilnor
     actions:
       - gather
-      - bank
   - name: Wilnor
     actions:
       - gather
-      - bank
   - name: Jilnor
     actions:
       - gather
-      - bank
   - name: Vilnor
     actions:
       - gather
-      - bank
       - refine

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/promiseofcake/artifactsmmo-engine/internal/actions"
 	"github.com/promiseofcake/artifactsmmo-engine/internal/engine"
 	"github.com/promiseofcake/artifactsmmo-engine/internal/logging"
+	"github.com/promiseofcake/artifactsmmo-engine/internal/models"
 )
 
 func init() {
@@ -33,9 +34,10 @@ const (
 )
 
 type Config struct {
-	Token      string      `mapstructure:"token"`
-	LogLevel   int         `mapstructure:"log_level"`
-	Characters []Character `mapstructure:"characters"`
+	Token      string             `mapstructure:"token"`
+	LogLevel   int                `mapstructure:"log_level"`
+	Characters []Character        `mapstructure:"characters"`
+	Orders     models.SimpleItems `mapstructure:"orders"`
 }
 
 type Character struct {
@@ -74,7 +76,7 @@ func main() {
 
 		charCtx := logging.ContextWithLogger(ctx, slog.With("character", c.Name))
 		l := logging.Get(charCtx)
-		l.Info("starting BuildInventory engine", "actions", c.Actions)
+		l.Info("starting execute engine", "actions", c.Actions)
 
 		go func(charCtx context.Context) {
 			defer wg.Done()
@@ -82,7 +84,7 @@ func main() {
 			if err != nil {
 				log.Fatal(err)
 			}
-			err = engine.BuildInventory(charCtx, r, c.Name, c.Actions)
+			err = engine.Execute(charCtx, r, c.Name, c.Actions, cfg.Orders)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/internal/actions/state.go
+++ b/internal/actions/state.go
@@ -11,19 +11,19 @@ import (
 )
 
 // GetBankItems returns all items in the bank
-func (r *Runner) GetBankItems(ctx context.Context) (models.BankItems, error) {
+func (r *Runner) GetBankItems(ctx context.Context) (models.SimpleItems, error) {
 	resp, err := r.Client.GetBankItemsMyBankItemsGetWithResponse(ctx, &client.GetBankItemsMyBankItemsGetParams{})
 	if err != nil {
-		return models.BankItems{}, fmt.Errorf("failed to get bank items: %w", err)
+		return models.SimpleItems{}, fmt.Errorf("failed to get bank items: %w", err)
 	}
 
 	if resp.StatusCode() != http.StatusOK {
-		return models.BankItems{}, fmt.Errorf("failed to get bank items: %s (%d)", resp.Body, resp.StatusCode())
+		return models.SimpleItems{}, fmt.Errorf("failed to get bank items: %s (%d)", resp.Body, resp.StatusCode())
 	}
 
-	var bank models.BankItems
+	var bank models.SimpleItems
 	for _, i := range resp.JSON200.Data {
-		item := models.BankItem{
+		item := models.SimpleItem{
 			Code:     i.Code,
 			Quantity: i.Quantity,
 		}
@@ -55,8 +55,44 @@ func (r *Runner) GetMyCharacterInfo(ctx context.Context, character string) (mode
 	return models.Character{}, fmt.Errorf("failed to find character: %s", character)
 }
 
-// GetMaps fetches world state based upon a given content type
-func (r *Runner) GetMaps(ctx context.Context, contentType client.GetAllMapsMapsGetParamsContentType) (models.Locations, error) {
+// GetMapsByContentCode fetches world state based upon a given content code
+func (r *Runner) GetMapsByContentCode(ctx context.Context, contentCode string) (models.Locations, error) {
+	resp, err := r.Client.GetAllMapsMapsGetWithResponse(ctx, &client.GetAllMapsMapsGetParams{
+		ContentCode: &contentCode,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch maps for content: %s %w", contentCode, err)
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch maps: %s (%d)", resp.Body, resp.StatusCode())
+	}
+
+	var locs models.Locations
+	for _, l := range resp.JSON200.Data {
+		s, dataErr := l.Content.AsMapContentSchema()
+		if dataErr != nil {
+			return nil, fmt.Errorf("failed to extra map content schema: %w", err)
+		}
+
+		loc := models.Location{
+			Name: l.Name,
+			Skin: l.Skin,
+			Coords: models.Coords{
+				X: l.X,
+				Y: l.Y,
+			},
+			Code: s.Code,
+			Type: s.Type,
+		}
+
+		locs = append(locs, loc)
+	}
+	return locs, nil
+}
+
+// GetMapsByContentType fetches world state based upon a given content type
+func (r *Runner) GetMapsByContentType(ctx context.Context, contentType client.GetAllMapsMapsGetParamsContentType) (models.Locations, error) {
 	resp, err := r.Client.GetAllMapsMapsGetWithResponse(ctx, &client.GetAllMapsMapsGetParams{
 		ContentType: &contentType,
 	})
@@ -174,7 +210,39 @@ func (r *Runner) GetMonsters(ctx context.Context, min, max int) (models.Monsters
 	return monsters, nil
 }
 
-func (r *Runner) GetResources(ctx context.Context, skill client.ResourceSchemaSkill, min, max int) (models.Resources, error) {
+func (r *Runner) GetResourcesByDrop(ctx context.Context, drop string) (models.Resources, error) {
+	resp, err := r.Client.GetAllResourcesResourcesGetWithResponse(ctx, &client.GetAllResourcesResourcesGetParams{
+		Drop: &drop,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch resources for drop %s, %w", drop, err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("status failure (%d), message: %s", resp.StatusCode(), resp.Body)
+	}
+
+	var resources models.Resources
+	for _, res := range resp.JSON200.Data {
+
+		locations, lErr := r.GetMapsByContentCode(ctx, res.Code)
+		if lErr != nil || len(locations) == 0 {
+			return nil, fmt.Errorf("failed to find resource locations: %w", err)
+		}
+
+		resource := models.Resource{
+			Name:     res.Name,
+			Code:     res.Code,
+			Skill:    res.Skill,
+			Level:    res.Level,
+			Location: locations[0], // todo allow more locations
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+func (r *Runner) GetResourcesBySkill(ctx context.Context, skill client.ResourceSchemaSkill, min, max int) (models.Resources, error) {
 	if min < 0 {
 		min = 0
 	}

--- a/internal/engine/decision.go
+++ b/internal/engine/decision.go
@@ -55,7 +55,7 @@ func Execute(ctx context.Context, r *actions.Runner, character string, actions [
 
 			l.Debug("checking for orders to fulfil", "orders", orders)
 			for _, o := range orders {
-				if ShouldFulfilOrder(ctx, r, o) {
+				if ShouldFulfilOrder(ctx, r, c, o) {
 					l.Debug("order required to be fulfilled", "order", o)
 					oErr := FulfilOrder(ctx, r, character, o)
 					if oErr != nil {

--- a/internal/engine/fight.go
+++ b/internal/engine/fight.go
@@ -21,7 +21,7 @@ func Fight(ctx context.Context, r *actions.Runner, character string) error {
 		return err
 	}
 
-	monsterLocations, err := r.GetMaps(ctx, client.Monster)
+	monsterLocations, err := r.GetMapsByContentType(ctx, client.Monster)
 	if err != nil {
 		l.Error("failed to get monster locations", "error", err)
 		return err

--- a/internal/engine/gather.go
+++ b/internal/engine/gather.go
@@ -1,13 +1,9 @@
 package engine
 
 import (
-	"cmp"
 	"context"
 	"fmt"
-	"slices"
 	"time"
-
-	"github.com/promiseofcake/artifactsmmo-go-client/client"
 
 	"github.com/promiseofcake/artifactsmmo-engine/internal/actions"
 	"github.com/promiseofcake/artifactsmmo-engine/internal/logging"
@@ -23,29 +19,12 @@ func Forage(ctx context.Context, r *actions.Runner, character string) error {
 		return err
 	}
 
-	resourceLoations, err := r.GetMapsByContentType(ctx, client.Resource)
-	if err != nil {
-		l.Error("failed to get resource locations", "error", err)
-		return err
-	}
-
 	skill := c.ChooseWeakestSkill()
-	resourceInfo, err := r.GetResourcesBySkill(ctx, skill.Code, skill.MinLevel, skill.CurrentLevel)
+	resources, err := r.GetResourcesBySkill(ctx, skill.Code, skill.MinLevel, skill.CurrentLevel)
 	if err != nil {
 		l.Error("failed to get resources", "error", err)
 		return err
 	}
-
-	loc := models.LocationsToMap(resourceLoations)
-	res := models.ResourcesToMap(resourceInfo)
-	// TODO there are more than one resource available, we should move to the one closet to the bank
-	// implement with manhattan distance
-	res.FindResources(loc)
-
-	resources := res.ToSlice()
-	slices.SortFunc(resources, func(a, b models.Resource) int {
-		return cmp.Compare(b.Level, a.Level)
-	})
 
 	if len(resources) == 0 {
 		err = fmt.Errorf("no suitable resources found")

--- a/internal/engine/gather.go
+++ b/internal/engine/gather.go
@@ -14,8 +14,8 @@ import (
 	"github.com/promiseofcake/artifactsmmo-engine/internal/models"
 )
 
-// Gather will attempt to Gather resources until the character should bank
-func Gather(ctx context.Context, r *actions.Runner, character string) error {
+// Forage will attempt to Forage resources until the character should bank
+func Forage(ctx context.Context, r *actions.Runner, character string) error {
 	l := logging.Get(ctx)
 	c, err := r.GetMyCharacterInfo(ctx, character)
 	if err != nil {
@@ -23,14 +23,14 @@ func Gather(ctx context.Context, r *actions.Runner, character string) error {
 		return err
 	}
 
-	resourceLoations, err := r.GetMaps(ctx, client.Resource)
+	resourceLoations, err := r.GetMapsByContentType(ctx, client.Resource)
 	if err != nil {
 		l.Error("failed to get resource locations", "error", err)
 		return err
 	}
 
 	skill := c.ChooseWeakestSkill()
-	resourceInfo, err := r.GetResources(ctx, skill.Code, skill.MinLevel, skill.CurrentLevel)
+	resourceInfo, err := r.GetResourcesBySkill(ctx, skill.Code, skill.MinLevel, skill.CurrentLevel)
 	if err != nil {
 		l.Error("failed to get resources", "error", err)
 		return err
@@ -60,13 +60,26 @@ func Gather(ctx context.Context, r *actions.Runner, character string) error {
 	// check if we should bank straight away
 	if c.ShouldBank() {
 		l.Debug("character will bank")
-		return nil
+		return DepositAll(ctx, r, character)
+	}
+
+	return Gather(ctx, r, character, resource)
+}
+
+// Gather will move to, and gather loop a resource
+func Gather(ctx context.Context, r *actions.Runner, character string, resource models.Resource) error {
+	l := logging.Get(ctx)
+
+	c, err := r.GetMyCharacterInfo(ctx, character)
+	if err != nil {
+		l.Error("failed to get character", "error", err)
+		return err
 	}
 
 	mErr := Move(ctx, r, character, resource.GetCoords())
 	if mErr != nil {
-		l.Error("failed to move", "error", err)
-		return err
+		l.Error("failed to move", "error", mErr)
+		return mErr
 	}
 
 	// harvest resource until we should stop
@@ -87,7 +100,7 @@ func Gather(ctx context.Context, r *actions.Runner, character string) error {
 
 			if c.ShouldBank() {
 				l.Debug("character will bank")
-				return nil
+				return DepositAll(ctx, r, character)
 			}
 		}
 	}

--- a/internal/engine/movement.go
+++ b/internal/engine/movement.go
@@ -40,7 +40,7 @@ func Move(ctx context.Context, r *actions.Runner, character string, coords model
 // Travel facilitates travel to the nearest location for a given type/code
 func Travel(ctx context.Context, r *actions.Runner, character string, location models.Location) error {
 	l := logging.Get(ctx)
-	maps, err := r.GetMaps(ctx, client.GetAllMapsMapsGetParamsContentType(location.Type))
+	maps, err := r.GetMapsByContentType(ctx, client.GetAllMapsMapsGetParamsContentType(location.Type))
 	if err != nil {
 		l.Error("failed to get maps", "error", err)
 		return err

--- a/internal/engine/order.go
+++ b/internal/engine/order.go
@@ -26,8 +26,6 @@ func ShouldFulfilOrder(ctx context.Context, r *actions.Runner, order models.Simp
 		}
 	}
 
-	logging.Get(ctx).Debug("")
-
 	if bankItem.Quantity < order.Quantity {
 		logging.Get(ctx).Debug("order quantity is greater than quantity on hand", "resource", order.Code, "required", order.Quantity, "on_hand", bankItem.Quantity)
 		return true

--- a/internal/engine/order.go
+++ b/internal/engine/order.go
@@ -1,0 +1,73 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/promiseofcake/artifactsmmo-engine/internal/actions"
+	"github.com/promiseofcake/artifactsmmo-engine/internal/logging"
+	"github.com/promiseofcake/artifactsmmo-engine/internal/models"
+)
+
+// ShouldFulfilOrder determines if this order is still relevant / should be fulfilled
+// it's based upon the quantity on hand in bank, not counting items in flight
+func ShouldFulfilOrder(ctx context.Context, r *actions.Runner, order models.SimpleItem) bool {
+	// determine what's in the bank
+	items, err := r.GetBankItems(ctx)
+	if err != nil {
+		return false
+	}
+
+	var bankItem models.SimpleItem
+	for _, item := range items {
+		if item.Code == order.Code {
+			bankItem = item
+			break
+		}
+	}
+
+	logging.Get(ctx).Debug("")
+
+	if bankItem.Quantity < order.Quantity {
+		logging.Get(ctx).Debug("order quantity is greater than quantity on hand", "resource", order.Code, "required", order.Quantity, "on_hand", bankItem.Quantity)
+		return true
+	} else {
+		return false
+	}
+
+}
+
+// FulfilOrder will instruct the character to seek out and gather the required resource
+func FulfilOrder(ctx context.Context, r *actions.Runner, character string, order models.SimpleItem) error {
+	// determine all resources that drop the order
+	resources, err := r.GetResourcesByDrop(ctx, order.Code)
+	if err != nil {
+		return fmt.Errorf("get resources by drop: %w", err)
+	}
+
+	// get character location
+	c, err := r.GetMyCharacterInfo(ctx, character)
+	if err != nil {
+		return fmt.Errorf("get character info: %w", err)
+	}
+
+	if c.ShouldBank() {
+		dErr := DepositAll(ctx, r, character)
+		if dErr != nil {
+			return fmt.Errorf("failed to deposit all: %w", dErr)
+		}
+	}
+
+	// goto the nearest resource
+	gErr := Gather(ctx, r, character, resources[0])
+	if gErr != nil {
+		return fmt.Errorf("failed to gather resources: %w", gErr)
+	} else {
+		dErr := DepositAll(ctx, r, character)
+		if dErr != nil {
+			return fmt.Errorf("failed to deposit all: %w", dErr)
+		}
+	}
+
+	return nil
+}

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -2,9 +2,9 @@ package models
 
 import "github.com/promiseofcake/artifactsmmo-go-client/client"
 
-type BankItems []BankItem
+type SimpleItems []SimpleItem
 
-type BankItem struct {
+type SimpleItem struct {
 	Code     string `json:"code"`
 	Quantity int    `json:"quantity"`
 }

--- a/internal/models/resource.go
+++ b/internal/models/resource.go
@@ -22,31 +22,3 @@ func (r Resource) GetCoords() Coords {
 		Y: r.Location.Coords.Y,
 	}
 }
-
-func resourcePK(resource Resource) string {
-	return "resource|" + resource.Code
-}
-
-func ResourcesToMap(resources Resources) ResourceMap {
-	resourceMap := make(ResourceMap)
-	for _, r := range resources {
-		resourceMap[resourcePK(r)] = &r
-	}
-	return resourceMap
-}
-
-func (r ResourceMap) FindResources(l LocationMap) {
-	for _, v := range r {
-		if loc, ok := l[resourcePK(*v)]; ok {
-			v.Location = loc
-		}
-	}
-}
-
-func (r ResourceMap) ToSlice() Resources {
-	var resources Resources
-	for _, m := range r {
-		resources = append(resources, *m)
-	}
-	return resources
-}


### PR DESCRIPTION
- Banking isn't an independent action, it should be tightly coupled to gather.
- We want to supply a list of orders that characters will fufill as high priority until the order has been completed.
- Rename things
  - buildinventory -> execture
  - gather -> forage (to allow for gather action)  